### PR TITLE
Update portal script runner to use new resumable upload for large datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Overview
 
 This is the MIG public repo for using Script Runner to send datasets to the Dataset Exchange API. For set up instructions on how to use this repo with Script Runner and the Dataset Exchange API, please contact us at [support@movementinfrastructure.org](support@movementinfrastructure.org).
+
+**This is a public github repository. Don't check-in any information that could be considered sensitive.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ managed = true
 dev-dependencies = [
     "google-auth==2.29.0",
     "google-cloud-bigquery==3.25.0",
-    "mig-dx-api==0.1.9",
+    "mig-dx-api==0.1.10",
     "pytest>=8.3.3",
     "pytest-mock>=3.14.0",
 ]

--- a/run.py
+++ b/run.py
@@ -119,8 +119,7 @@ def get_upload_url(dataset: DatasetOperations, is_resumable: bool = False):
 
     return dataset.get_upload_url(mode='replace')
 
-def write_data_to_signed_url(source_data: list, destination_dataset: DatasetOperations):
-    upload_url = get_upload_url(destination_dataset)
+def write_data_to_signed_url(source_data: list, destination_dataset: DatasetOperations, upload_url: str):
     # Upload the data for the dataset in MIG to presigned url
     response = destination_dataset.upload_data_to_url(upload_url['url'], source_data)
     # Log results

--- a/run.py
+++ b/run.py
@@ -32,9 +32,9 @@ def get_target_installation(installations: list[Installation], target_installati
     else:
         if target_installation_id is None:
             raise Exception("More than one installation available and no target installation id specified")
-        target_installation_id = int(target_installation_id)
+        target_install_id = int(target_installation_id)
         for install in installations:
-            if install.installation_id == target_installation_id:
+            if install.installation_id == target_install_id:
                 target_install = install
                 break
         if target_install is None:

--- a/run.py
+++ b/run.py
@@ -1,7 +1,11 @@
 import argparse
+import csv
+import datetime
+import io
 import json
 import os
 import re
+import requests
 import google.auth
 from mig_dx_api import (
     DX,
@@ -11,6 +15,10 @@ from mig_dx_api import (
 )
 from mig_dx_api._dataset import DatasetOperations
 from google.cloud import bigquery
+CHUNK_SIZE = 1024 * 1024 * 16 # 16 MiB
+
+def get_formatted_date() -> str:
+    return datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
 
 def get_target_installation(installations: list[Installation], target_installation_id: str = None) -> Installation:
     if len(installations) == 0:
@@ -18,15 +26,15 @@ def get_target_installation(installations: list[Installation], target_installati
     elif len(installations) == 1:
         target_install = installations[0]
         # error if the target installation id doesn't match the only existing installation
-        if target_installation_id and target_install.installation_id != int(target_installation_id):
+        if target_installation_id and target_install.instalaltion_id != int(target_installation_id):
             raise Exception(f"Installation {target_installation_id} not found")
         return target_install
     else:
         if target_installation_id is None:
             raise Exception("More than one installation available and no target installation id specified")
-        target_install_id = int(target_installation_id)
+        target_installation_id = int(target_installation_id)
         for install in installations:
-            if install.installation_id == target_install_id:
+            if install.installation_id == target_installation_id:
                 target_install = install
                 break
         if target_install is None:
@@ -47,7 +55,7 @@ def get_schema(client: bigquery.Client, table_name: str, dataset_id: str, projec
     table_constraints = table.table_constraints # might not exist
     primary_key = table_constraints.primary_key.columns if table_constraints else []
 
-    print(f'bigquery schema: {schema}')
+    print(f'{get_formatted_date()} | bigquery schema: {schema}')
     print(f'table constraints: {primary_key}')
 
     properties = []
@@ -72,7 +80,7 @@ def create_dataset(dx: DX, installation: Installation, dataset_name: str, datase
             description='Dataset created through Portal Script Runner',
             schema=dataset_schema
         )
-        print(f'new dataset: {new_dataset}')
+        print(f'{get_formatted_date()} | new dataset: {new_dataset}')
         return new_dataset
 
 def get_source_data(client: bigquery.Client, dataset_id: str, table_name: str) -> list:
@@ -88,20 +96,79 @@ def get_source_data(client: bigquery.Client, dataset_id: str, table_name: str) -
     """
     query_job = client.query(sql)
     rows = query_job.result()
+    print(f'{get_formatted_date()} | fetched {rows.total_rows:,} rows from {dataset_id}.{table_name}')
     data = []
     for row in rows:
         row_data_string = row.values()[0]
         data.append(json.loads(row_data_string))
+    print(f'{get_formatted_date} | finished collecting data')
     return data
 
-def write_data_to_file(source_data: list, destination_dataset: DatasetOperations, upload_url: str):
+def get_upload_url(dataset: DatasetOperations, is_resumable: bool = False):
+    if is_resumable:
+        return dataset.get_upload_url(mode='replace', upload_type='resumable')
+
+    return dataset.get_upload_url(mode='replace')
+
+def write_data_to_file(source_data: list, destination_dataset: DatasetOperations):
     """
     Write data from Portal source dataset to file in MiG landing bucket
     """
-    # Upload the data for the dataset in MIG to presigned url
-    response = destination_dataset.upload_data_to_url(upload_url['url'], source_data)
-    # Log results
-    print(f'upload response: {response}')
+    fieldnames = source_data[0].keys()
+    _buffer = io.StringIO()
+    writer = csv.DictWriter(_buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(source_data)
+
+    # estimate size of file based on number of characters
+    approx_data_size = _buffer.tell()
+    _buffer.seek(0)
+
+    print(f'{get_formatted_date}| data size: {approx_data_size} bytes')
+
+    if (approx_data_size > CHUNK_SIZE):
+        print(f'data size is larger than {CHUNK_SIZE} bytes so sending in chunks')
+        upload_url = get_upload_url(destination_dataset, True)
+
+        # Track the start byte for each chunk
+        start_byte = 0
+
+        # Iterate over the buffered data by chunk
+        while True:
+            chunk = _buffer.read(CHUNK_SIZE)
+            if not chunk:
+                print('end of file, break')
+                break  # Break if the end of file is reached
+
+            end_byte = start_byte + len(chunk) - 1
+            headers = {
+                "Content-Range": f"bytes {start_byte}-{end_byte}/{approx_data_size}",
+                "Content-Type": "text/csv",
+            }
+            print(f'{get_formatted_date} | attempting to send {start_byte} to {end_byte} bytes')
+
+            # Upload the chunk
+            response = requests.put(upload_url['url'], headers=headers, data=chunk)
+            # response = requests.put(upload_url, headers=headers, data=chunk)
+            print(f'response: {response}')
+
+            if response.status_code in [200, 201]:
+                print("Upload complete.")
+                break  # Successfully uploaded the whole file
+            elif response.status_code == 308:
+                # 308 indicates that the upload is incomplete and we can continue
+                print(f"Uploaded bytes {start_byte} to {end_byte}")
+                start_byte = end_byte + 1
+            else:
+                # Handle upload failure
+                raise Exception(f"Upload failed: {response.text}")
+    else:
+        print(f'data size is smaller than {CHUNK_SIZE} bytes so sending all at once')
+        upload_url = get_upload_url(destination_dataset)
+        # Upload the data for the dataset in MIG to presigned url
+        response = destination_dataset.upload_data_to_url(upload_url['url'], source_data)
+        # Log results
+        print(f'upload response: {response}')
 
 def format_private_key(unformatted_key: str) -> str:
     """
@@ -155,11 +222,8 @@ def main(dataset_id: str, table_name: str, target_installation_id: str):
         # Get data from source dataset
         source_data = get_source_data(client, dataset_id, table_name)
 
-        # Get signed uploadurl from MIG
-        upload_url = destination_dataset.get_upload_url(mode='replace')
-
         # Write data to mig bucket for processing
-        write_data_to_file(source_data, destination_dataset, upload_url)
+        write_data_to_file(source_data, destination_dataset)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/run.py
+++ b/run.py
@@ -26,7 +26,7 @@ def get_target_installation(installations: list[Installation], target_installati
     elif len(installations) == 1:
         target_install = installations[0]
         # error if the target installation id doesn't match the only existing installation
-        if target_installation_id and target_install.instalaltion_id != int(target_installation_id):
+        if target_installation_id and target_install.installation_id != int(target_installation_id):
             raise Exception(f"Installation {target_installation_id} not found")
         return target_install
     else:

--- a/run.py
+++ b/run.py
@@ -72,9 +72,9 @@ def get_schema(client: bigquery.Client, table_name: str, dataset_id: str, projec
 
 def create_dataset(dx: DX, installation: Installation, dataset_name: str, dataset_schema: DatasetSchema) -> DatasetOperations:
     """
-    Create MiG dataset using mig-dx-api client
+    Create MIG dataset using mig-dx-api client
     """
-    # create MiG dataset with source schema
+    # create MIG dataset with source schema
     with dx.installation(installation) as ctx:
         new_dataset = ctx.datasets.create(
             name=dataset_name,
@@ -131,7 +131,7 @@ def write_chunked_data(
     upload_url: str,
     chunk_size: int):
     """
-    Write data from Portal source dataset to file in MiG landing bucket
+    Write data from Portal source dataset to file in MIG landing bucket
     """
     data_buffer.seek(0)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,6 +114,8 @@ def test_get_source_data(mock_bigquery):
     mock_query_job = mock.create_autospec(bigquery.QueryJob)
     # row data coming back from bigquery is a string, not json
     mock_rows = mock.create_autospec(bigquery.table.RowIterator)
+    mock_rows.total_rows = 6
+
     mock_rows.__iter__.return_value = [
         bigquery.Row(('{"van_id": 241, "first_name": "Erika", "last_name": "Testuser", "city": "Decatur", "state": "AL"}',), {'json':0}),
         bigquery.Row(('{"van_id": 110, "first_name": "Ulysses", "last_name": "Testuser", "city": "Hoover", "state": "AL"}',), {'json':0}),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,15 +2,17 @@ import pytest
 import datetime
 from google.cloud import bigquery
 from mig_dx_api import CreatedBy, Installation
+from mig_dx_api._dataset import DatasetOperations
 from uuid import uuid4
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from run import (
     get_target_installation,
     get_schema,
     get_source_data,
     create_data_buffer,
+    get_upload_url,
     format_private_key
 )
 
@@ -147,11 +149,23 @@ def test_create_data_buffer():
     assert approx_data_size_with_tell == 238
     assert approx_data_size_with_len == 238
 
-def test_get_upload_url_resumable():
-    assert True
+def test_get_resumable_upload_url():
+    datasetOps = DatasetOperations(MagicMock(), MagicMock())
+    datasetOps.get_upload_url = MagicMock()
 
-def test_get_upload_url_signed():
-    assert True
+    get_upload_url(datasetOps, True)
+
+    # Check if the method was called with the correct arguments
+    datasetOps.get_upload_url.assert_called_with(mode='replace', upload_type='resumable')
+
+def test_get_signed_upload_url():
+    datasetOps = DatasetOperations(MagicMock(), MagicMock())
+    datasetOps.get_upload_url = MagicMock()
+
+    get_upload_url(datasetOps)
+
+    # Check if the method was called with the correct arguments
+    datasetOps.get_upload_url.assert_called_with(mode='replace')
 
 def test_write_chunked_data():
     assert True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ import datetime
 from google.cloud import bigquery
 from mig_dx_api import CreatedBy, Installation
 from mig_dx_api._dataset import DatasetOperations
+import requests
 from uuid import uuid4
 from unittest import mock
 from unittest.mock import patch, MagicMock
@@ -13,6 +14,7 @@ from run import (
     get_source_data,
     create_data_buffer,
     get_upload_url,
+    write_chunked_data,
     format_private_key
 )
 
@@ -22,6 +24,14 @@ TEST_CREATOR = CreatedBy(
     user_id = 123,
     display_name = 'Test User',
     email = 'test@example.com')
+
+MOCK_RESPONSE_308 = MagicMock()
+MOCK_RESPONSE_308.status_code = 308
+MOCK_RESPONSE_200 = MagicMock()
+MOCK_RESPONSE_200.status_code = 200
+MOCK_RESPONSE_ERROR = MagicMock()
+MOCK_RESPONSE_ERROR.status_code = 500
+MOCK_RESPONSE_ERROR.text = 'Chunk failure'
 
 def test_get_target_installation_default():
     installations = [
@@ -66,7 +76,7 @@ def test_get_target_installation_no_installations():
     with pytest.raises(Exception) as exception_info:
         installations = []
         get_target_installation(installations)
-        assert str(exception_info.value) == "No valid installations found"
+    assert str(exception_info.value) == 'No valid installations found'
 
 def test_get_target_installation_with_installation_id_not_found():
     with pytest.raises(Exception) as exception_info:
@@ -89,7 +99,7 @@ def test_get_target_installation_with_installation_id_not_found():
             )
         ]
         get_target_installation(installations, '21')
-        assert str(exception_info.value) == "Installation 21 not found"
+    assert str(exception_info.value) == 'Installation 21 not found'
 
 @patch('google.cloud.bigquery.Client', autospec=True)
 def test_get_schema(mock_bigquery):
@@ -110,7 +120,7 @@ def test_get_schema(mock_bigquery):
     print(f'SCHEMA: {schema}')
     assert len(schema.properties) == 5
     assert schema.primary_key == [primary_key]
-    assert schema.properties[0].type == "string"
+    assert schema.properties[0].type == 'string'
 
 @patch('google.cloud.bigquery.Client', autospec=True)
 def test_get_source_data(mock_bigquery):
@@ -129,7 +139,7 @@ def test_get_source_data(mock_bigquery):
     ]
     mock_query_job.result.return_value = mock_rows
     mock_bigquery.query.return_value = mock_query_job
-    data = get_source_data(mock_bigquery, "dataset", "test_table")
+    data = get_source_data(mock_bigquery, 'dataset', 'test_table')
     assert len(data) == 6
     assert data[0]['van_id'] == 241
 
@@ -167,8 +177,48 @@ def test_get_signed_upload_url():
     # Check if the method was called with the correct arguments
     datasetOps.get_upload_url.assert_called_with(mode='replace')
 
-def test_write_chunked_data():
-    assert True
+@patch('requests.put', autospec=True, side_effect=[MOCK_RESPONSE_308, MOCK_RESPONSE_308, MOCK_RESPONSE_200])
+def test_write_chunked_data(mock_put):
+    # size of this data is 238, so should be sent in three chunks
+    source_data = [
+        {'van_id': 241, 'first_name': 'Erika', 'last_name': 'Testuser', 'city': 'Decatur', 'state': 'AL'},
+        {'van_id': 110, 'first_name': 'Ulysses', 'last_name': 'Testuser', 'city': 'Hoover', 'state': 'AL'},
+        {'van_id': 242, 'first_name': 'Earl', 'last_name': 'Testuser', 'city': 'Santa Clara', 'state': 'CA'},
+        {'van_id': 111, 'first_name': 'Quinn', 'last_name': 'Testuser', 'city': 'Clovis', 'state': 'CA'},
+        {'van_id': 103, 'first_name': 'Jane', 'last_name': 'Testuser', 'city': 'San Bernardino', 'state': 'CA'},
+        {'van_id': 117, 'first_name': 'Sylvia', 'last_name': 'Testuser', 'city': 'Elk Grove', 'state': 'CA'}
+    ]
+    data_buffer = create_data_buffer(source_data)
+    data_size = data_buffer.tell()
+    chunk_size = 100
+    upload_url = {'url' : 'https://example.com'}
+
+    write_chunked_data(data_buffer, data_size, upload_url, chunk_size)
+    
+    # check that requests put is called three times
+    assert mock_put.call_count == 3
+
+@patch('requests.put', autospec=True, side_effect=[MOCK_RESPONSE_ERROR])
+def test_write_chunked_data_throws_error(mock_put):
+    with pytest.raises(Exception) as exception_info:
+        # size of this data is 238, so should be sent in three chunks
+        source_data = [
+            {'van_id': 241, 'first_name': 'Erika', 'last_name': 'Testuser', 'city': 'Decatur', 'state': 'AL'},
+            {'van_id': 110, 'first_name': 'Ulysses', 'last_name': 'Testuser', 'city': 'Hoover', 'state': 'AL'},
+            {'van_id': 242, 'first_name': 'Earl', 'last_name': 'Testuser', 'city': 'Santa Clara', 'state': 'CA'},
+            {'van_id': 111, 'first_name': 'Quinn', 'last_name': 'Testuser', 'city': 'Clovis', 'state': 'CA'},
+            {'van_id': 103, 'first_name': 'Jane', 'last_name': 'Testuser', 'city': 'San Bernardino', 'state': 'CA'},
+            {'van_id': 117, 'first_name': 'Sylvia', 'last_name': 'Testuser', 'city': 'Elk Grove', 'state': 'CA'}
+        ]
+        data_buffer = create_data_buffer(source_data)
+        data_size = data_buffer.tell()
+        chunk_size = 100
+        upload_url = {'url' : 'https://example.com'}
+
+        write_chunked_data(data_buffer, data_size, upload_url, chunk_size)
+
+    # check that exception is thrown
+    assert str(exception_info.value) == f'Upload failed: {MOCK_RESPONSE_ERROR.text}'
 
 def test_format_private_key():
     unformatted_key = '-----BEGIN PRIVATE KEY-----MIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjELMAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgxNDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJDTjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFuZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7jV14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGjgbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaAFFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UEBQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+JuWm7DCfrPNGVwFWUQOmsPue9rZBgO-----END PRIVATE KEY-----'
@@ -180,4 +230,4 @@ def test_format_private_key_error():
     unformatted_key = '-----BEGIN CERTIFICATE-----MIICUTCCAfugAwIBAgIBADANDncEQX67aRfgZu7KWdI+JuWm7DCfrPNGVwFWUQOmsPue9rZBgO-----END CERTIFICATE-----'
     with pytest.raises(Exception) as exception_info:
         format_private_key(unformatted_key)
-        assert str(exception_info.value) == "Private key is malformed"
+        assert str(exception_info.value) == 'Private key is malformed'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ from run import (
     get_target_installation,
     get_schema,
     get_source_data,
+    create_data_buffer,
     format_private_key
 )
 
@@ -129,6 +130,31 @@ def test_get_source_data(mock_bigquery):
     data = get_source_data(mock_bigquery, "dataset", "test_table")
     assert len(data) == 6
     assert data[0]['van_id'] == 241
+
+def test_create_data_buffer():
+    source_data = [
+        {'van_id': 241, 'first_name': 'Erika', 'last_name': 'Testuser', 'city': 'Decatur', 'state': 'AL'},
+        {'van_id': 110, 'first_name': 'Ulysses', 'last_name': 'Testuser', 'city': 'Hoover', 'state': 'AL'},
+        {'van_id': 242, 'first_name': 'Earl', 'last_name': 'Testuser', 'city': 'Santa Clara', 'state': 'CA'},
+        {'van_id': 111, 'first_name': 'Quinn', 'last_name': 'Testuser', 'city': 'Clovis', 'state': 'CA'},
+        {'van_id': 103, 'first_name': 'Jane', 'last_name': 'Testuser', 'city': 'San Bernardino', 'state': 'CA'},
+        {'van_id': 117, 'first_name': 'Sylvia', 'last_name': 'Testuser', 'city': 'Elk Grove', 'state': 'CA'}
+    ]
+    data_buffer = create_data_buffer(source_data)
+
+    approx_data_size_with_tell = data_buffer.tell()
+    approx_data_size_with_len = len(data_buffer.getvalue())
+    assert approx_data_size_with_tell == 238
+    assert approx_data_size_with_len == 238
+
+def test_get_upload_url_resumable():
+    assert True
+
+def test_get_upload_url_signed():
+    assert True
+
+def test_write_chunked_data():
+    assert True
 
 def test_format_private_key():
     unformatted_key = '-----BEGIN PRIVATE KEY-----MIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjELMAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgxNDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJDTjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFuZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7jV14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGjgbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaAFFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UEBQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+JuWm7DCfrPNGVwFWUQOmsPue9rZBgO-----END PRIVATE KEY-----'

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ dev = [
 dev = [
     { name = "google-auth", specifier = "==2.29.0" },
     { name = "google-cloud-bigquery", specifier = "==3.25.0" },
-    { name = "mig-dx-api", specifier = "==0.1.9" },
+    { name = "mig-dx-api", specifier = "==0.1.10" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
@@ -389,7 +389,7 @@ wheels = [
 
 [[package]]
 name = "mig-dx-api"
-version = "0.1.9"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -399,9 +399,9 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/5df32db39b2193703108eff9f6ee74b542e128843a2e073ea315b5616494/mig_dx_api-0.1.9.tar.gz", hash = "sha256:b9a123db73a94e543fa82fe2a1b096ff21a3cbb0fc9d8652915857c27e3fe9be", size = 54964 }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/6a/0ffe3392439869f283f265831e05e3d090d0a721327bcf52230990e9e6dc/mig_dx_api-0.1.10.tar.gz", hash = "sha256:55b6fed12a4d7a1c268a06eb4da35eb53ad41b15a13155d2782358e2a3222d51", size = 56427 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/4e8468ab1c1445785ffe07914874305696703167d3804cafbd8ea1764464/mig_dx_api-0.1.9-py3-none-any.whl", hash = "sha256:704f866fc69d33a4c484dbc358c768d35e2a06d8c737f1666cb246a0de0d9579", size = 11980 },
+    { url = "https://files.pythonhosted.org/packages/54/93/6061870d0c3c1dfc96b8bd91b72f565373c1210e20602c0d51b1fbabdd40/mig_dx_api-0.1.10-py3-none-any.whl", hash = "sha256:b70f1bd2d5e098dd215b1f5f38e9eb935f730189541588409304af3efeed6890", size = 12018 },
 ]
 
 [[package]]


### PR DESCRIPTION
Updated portal runner script to upload large datasets in chunks. This uses the new `resumable` upload uri that can now be returned from the `/datasets/:datasetId/uploadUrl` endpoint.

Added tests and updated the README to include a reminder that this is a public repository.